### PR TITLE
Init

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -21,6 +24,13 @@ jobs:
           node-version: 18
           registry-url: 'https://registry.npmjs.org/'
           cache: 'npm'
+          always-auth: true
+
+      - name: Configure npm auth
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install dependencies
         run: npm ci
@@ -34,6 +44,6 @@ jobs:
           npm run build
 
       - name: Publish
-        run: npm publish --access public
+        run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-jira-stdio",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Model Context Protocol (MCP) server for Jira API integration",
   "author": "graslt",
   "license": "MIT",


### PR DESCRIPTION
This pull request updates the publishing workflow and versioning for the MCP Jira integration package. The main changes improve the security and reliability of the npm publishing process and increment the package version.

**Workflow and publishing improvements:**

* Added explicit permissions (`contents: read`, `id-token: write`) to the GitHub Actions workflow to enhance security during publishing.
* Enabled `always-auth` and configured npm authentication using the `NPM_TOKEN` secret for secure registry access.
* Updated the publish step to use the `--provenance` flag, providing additional supply chain security metadata.

**Version update:**

* Bumped the package version in `package.json` from `1.0.1` to `1.0.2`.