### PR TITLE
fix: parse stringified ADF when format is adf

### DIFF
--- a/src/utils/api-helpers.ts
+++ b/src/utils/api-helpers.ts
@@ -43,8 +43,23 @@ function ensureAdfDescription(desc: any, format: 'markdown' | 'adf' | 'plain' = 
     }
   }
 
-  // Handle ADF format (already handled above with typeof === 'object')
+  // Handle ADF format: MCP passes stringified JSON; Jira REST API expects an object.
+  // (typeof === 'object' is handled above — return as-is.)
   if (format === 'adf') {
+    if (typeof desc === 'string') {
+      const trimmed = desc.trim();
+      try {
+        const parsed = JSON.parse(trimmed) as { type?: string };
+        if (parsed && typeof parsed === 'object' && parsed.type === 'doc') {
+          return parsed;
+        }
+      } catch {
+        // fall through to error below
+      }
+      throw new Error(
+        'ADF format: body must be a JSON string that parses to an ADF document with type "doc" (stringified Atlassian Document Format).'
+      );
+    }
     return desc;
   }
 

--- a/tests/unit/utils/markdown-conversion.test.ts
+++ b/tests/unit/utils/markdown-conversion.test.ts
@@ -119,23 +119,24 @@ describe('Markdown Format Conversion', () => {
       expect(call.data.fields.description).toEqual(adfObject);
     });
 
-    it('should return string as-is when format is "adf" and description is string', async () => {
+    it('should JSON.parse description string when format is "adf" (MCP always sends strings)', async () => {
       const mockResponse = { key: 'TEST-123', id: '123', self: 'url' };
       const mockIssue = { key: 'TEST-123', fields: {} };
+      const adfDoc = { type: 'doc', version: 1, content: [] };
 
       mockedMakeJiraRequest.mockResolvedValueOnce(mockResponse).mockResolvedValueOnce(mockIssue);
 
       await createIssue({
         projectKey: 'TEST',
         summary: 'Test',
-        description: 'raw string',
+        description: JSON.stringify(adfDoc),
         issueType: 'Task',
         format: 'adf',
       });
 
       expect(mockedMdToAdf).not.toHaveBeenCalled();
       const call = mockedMakeJiraRequest.mock.calls[0][0];
-      expect(call.data.fields.description).toBe('raw string');
+      expect(call.data.fields.description).toEqual(adfDoc);
     });
 
     it('should use markdown format by default', async () => {
@@ -184,6 +185,31 @@ describe('Markdown Format Conversion', () => {
       await addComment('TEST-123', '# Comment\n\n**Bold**', undefined, 'markdown');
 
       expect(mockedMdToAdf).toHaveBeenCalledWith('# Comment\n\n**Bold**');
+    });
+  });
+
+  describe('addComment with adf format', () => {
+    it('should JSON.parse string body and send ADF object to Jira (not a raw string)', async () => {
+      const mockComment = { id: '1', body: {}, author: {} };
+      mockedMakeJiraRequest.mockResolvedValue(mockComment);
+
+      const adfDoc = {
+        type: 'doc' as const,
+        version: 1,
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'Hello from ADF' }],
+          },
+        ],
+      };
+
+      await addComment('TEST-123', JSON.stringify(adfDoc), undefined, 'adf');
+
+      expect(mockedMdToAdf).not.toHaveBeenCalled();
+      const call = mockedMakeJiraRequest.mock.calls[0][0];
+      expect(call.data.body).toEqual(adfDoc);
+      expect(typeof call.data.body).toBe('object');
     });
   });
 });


### PR DESCRIPTION
MCP tool schemas require body/description as strings. For format "adf", ensureAdfDescription returned the raw string, so Jira REST received a string instead of an ADF object (comments failed with invalid body).

- JSON.parse trimmed string when it looks like JSON with type "doc"
- Throw a clear error when parsing fails or root is not an ADF doc
- Update tests: createIssue and addComment send parsed objects to Jira
