### PR TITLE
chore: target Docker image at node:22-alpine (LTS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:18-alpine AS builder
+FROM node:22-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache python3 make g++
@@ -19,7 +19,7 @@ COPY . .
 RUN npm run build
 
 # Production stage
-FROM node:18-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MCP Jira Server
 
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.0%2B-007ACC?logo=typescript&logoColor=white)](https://www.typescriptlang.org)
-[![Node](https://img.shields.io/badge/Node.js-18%2B-339933?logo=node.js&logoColor=white)](https://nodejs.org)
+[![Node](https://img.shields.io/badge/Node.js-20%2B-339933?logo=node.js&logoColor=white)](https://nodejs.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![npm version](https://badge.fury.io/js/mcp-jira-stdio.svg)](https://www.npmjs.com/package/mcp-jira-stdio)
 [![MCP Server](https://img.shields.io/badge/MCP-Server-blue)](https://glama.ai/mcp/servers)
@@ -42,7 +42,7 @@ If you prefer to configure manually or use Claude Desktop, see the [Configuratio
 
 ### 1. Prerequisites
 
-- Node.js v18 or higher
+- Node.js v20 or higher
 - Jira instance (Cloud or Server)
 - Jira API token
 


### PR DESCRIPTION
Supersedes #219.

#219 (dependabot) bumped the Docker base image from `node:18-alpine` straight to `node:26-alpine`. Moving off 18 is correct — it's below the `package.json` `engines` floor (`>=20.0.0`) — but **node:26 is non-LTS**, and the CI workflow never builds or runs the Docker image (the matrix only covers Node 20/22/24), so a green check on #219 proves nothing about the image.

This PR instead targets **`node:22-alpine`** (active LTS, and in the CI matrix) for both the build and production stages, and syncs the stale README Node references (badge + prerequisites: 18 → 20) to match `engines`.

### Verification
Local multi-stage `docker build` (which CI does not do):
- ✅ image builds end-to-end
- ✅ runs `node v22.x`
- ✅ produces `dist/index.js`

### Note (out of scope)
There is no `.dockerignore`, so `COPY . .` copies the local `node_modules` into the build context. Worth adding separately, but left out of this change to keep it focused on the Node version.