### PR TITLE
feat: publish to MCP Registry

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,59 @@
+name: Publish to MCP Registry
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Sync server.json version with release tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if [ -z "$VERSION" ] || [ "$VERSION" = "$GITHUB_REF_NAME" ]; then
+            VERSION=$(node -p "require('./package.json').version")
+          fi
+          echo "Publishing version: $VERSION"
+          node -e "
+            const fs = require('fs');
+            const s = JSON.parse(fs.readFileSync('server.json', 'utf8'));
+            s.version = '$VERSION';
+            for (const p of s.packages || []) p.version = '$VERSION';
+            fs.writeFileSync('server.json', JSON.stringify(s, null, 2) + '\n');
+          "
+          cat server.json
+
+      - name: Wait for npm package to be available
+        run: |
+          VERSION=$(node -p "require('./server.json').version")
+          echo "Waiting for mcp-jira-stdio@$VERSION on npm..."
+          for i in $(seq 1 60); do
+            if npm view "mcp-jira-stdio@$VERSION" version 2>/dev/null | grep -q "^$VERSION$"; then
+              echo "Package available."
+              exit 0
+            fi
+            echo "Not yet (attempt $i/60), sleeping 10s..."
+            sleep 10
+          done
+          echo "Timed out waiting for npm package."
+          exit 1
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+          chmod +x mcp-publisher
+
+      - name: Login to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- mcp-name: io.github.freema/mcp-jira-stdio -->
+
 # MCP Jira Server
 
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.0%2B-007ACC?logo=typescript&logoColor=white)](https://www.typescriptlang.org)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mcp-jira-stdio",
-  "version": "1.10.2",
+  "version": "1.11.0",
+  "mcpName": "io.github.freema/mcp-jira-stdio",
   "description": "Model Context Protocol (MCP) server for Jira API integration",
   "author": "graslt",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "name": "io.github.freema/mcp-jira-stdio",
+  "description": "MCP server for Jira Cloud — issues, search, comments, attachments, transitions.",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/freema/mcp-jira-stdio",
+    "source": "github"
+  },
+  "version": "1.11.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "mcp-jira-stdio",
+      "version": "1.11.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "JIRA_BASE_URL",
+          "description": "Jira instance URL, e.g. https://company.atlassian.net",
+          "isRequired": true
+        },
+        {
+          "name": "JIRA_EMAIL",
+          "description": "Email of the Jira account the API token belongs to",
+          "isRequired": true
+        },
+        {
+          "name": "JIRA_API_TOKEN",
+          "description": "Jira API token (id.atlassian.com > Security > API tokens)",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "MCP_REDACT_SENSITIVE",
+          "description": "Set to true to redact sensitive values from logs",
+          "isRequired": false
+        },
+        {
+          "name": "LOG_LEVEL",
+          "description": "Log verbosity: debug, info, warn or error (default: info)",
+          "isRequired": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Registers `mcp-jira-stdio` in the [MCP Registry](https://registry.modelcontextprotocol.io) as `io.github.freema/mcp-jira-stdio`, the same setup mcp-gsheets and mcp-design-system-extractor already use.

- `server.json` — env vars taken from an actual grep of `process.env.*` in `src/`, so the registry entry lists exactly what the server reads: `JIRA_BASE_URL`, `JIRA_EMAIL`, `JIRA_API_TOKEN` (required, secret) plus optional `MCP_REDACT_SENSITIVE` and `LOG_LEVEL`.
- `.github/workflows/publish-mcp-registry.yml` — runs on release published, syncs `server.json` to the tag, waits for npm to serve the version, authenticates over GitHub OIDC and publishes. No new secrets.
- `mcpName` in `package.json` and the `<!-- mcp-name: ... -->` comment at the top of the README — both are what the validator checks to confirm npm ownership.
- Version 1.10.2 → 1.11.0 so there is a release to hang the publish on.

`npm run check:all` passes: 348 tests, typecheck, lint, format, build.