### PR TITLE
chore: release 1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.1] - 2026-08-10
+
+### Changed
+
+- Bumped `axios` from 1.18.1 to 1.19.0
+- Bumped `zod` from 4.4.2 to 4.4.3
+- Bumped `eslint` from 9.39.4 to 9.39.5
+- Bumped the vitest group (`vitest`, `@vitest/coverage-v8`, `@vitest/ui`) from 4.1.9 to 4.1.10
+- Bumped `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` from 8.62.1 to 8.65.0
+- Bumped `actions/checkout` from 4 to 7 and `actions/setup-node` from 6 to 7 in CI
+
 ## [1.10.2] - 2026-04-21
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-jira-stdio",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-jira-stdio",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-jira-stdio",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "mcpName": "io.github.freema/mcp-jira-stdio",
   "description": "Model Context Protocol (MCP) server for Jira API integration",
   "author": "graslt",


### PR DESCRIPTION
Patch release covering the dependency updates merged since v1.11.0 (#230-#236).

- axios 1.18.1 -> 1.19.0
- zod 4.4.2 -> 4.4.3
- eslint 9.39.4 -> 9.39.5
- vitest group 4.1.9 -> 4.1.10
- typescript-eslint 8.62.1 -> 8.65.0
- actions/checkout 4 -> 7, actions/setup-node 6 -> 7

axios and zod are bundled into `dist/index.js` by tsup, so these land in the published artifact.